### PR TITLE
Dbus: Add interfaces for Scheduled Host Transition

### DIFF
--- a/xyz/openbmc_project/ScheduledTime.errors.yaml
+++ b/xyz/openbmc_project/ScheduledTime.errors.yaml
@@ -1,0 +1,2 @@
+- name: InvalidTime
+  description: Scheduled time is in the past

--- a/xyz/openbmc_project/ScheduledTime.metadata.yaml
+++ b/xyz/openbmc_project/ScheduledTime.metadata.yaml
@@ -1,0 +1,5 @@
+- name: InvalidTime
+  level: ERR
+  meta:
+    - str: "REASON=%s"
+      type: string

--- a/xyz/openbmc_project/State/ScheduledHostTransition.interface.yaml
+++ b/xyz/openbmc_project/State/ScheduledHostTransition.interface.yaml
@@ -1,0 +1,50 @@
+description: >
+    Implement to schedule Epoch time to power on/off the Host.
+properties:
+    - name: ScheduledTime
+      type: uint64
+      default: 0
+      description: >
+          ScheduledTime is a date time when the host will be
+          powered on/off. The time is the Epoch time, number
+          of seconds since 1 Jan 1970 00::00::00 UTC.
+
+          When ScheduledTime is 0, it means the functionality
+          is disabled.
+          When ScheduledTime is smaller than current time,
+          error InvalidTime will be thrown.
+          When the controller detects the ScheduledTime has passed,
+          it will execute the RequestedTransition and reset the
+          value to 0. Once the transition starts, there won't be
+          any retries.
+          When the real time is changed, the controller shall
+          restart a new timer if the ScheduledTime is still not
+          reached. Otherwise, stop the timer and check the state
+          of host. If the state is not the same as required, set it
+          as RequestedTransition.
+          When ScheduledTime is reached, but the host is not ready
+          to power on/off, e.g. when BMC is rebooting, BMC shall
+          set the host RequestedTransition after it is ready.
+      errors:
+        - xyz.openbmc_project.ScheduledTime.Error.InvalidTime
+
+    - name: RequestedTransition
+      type: enum[self.Transition]
+      default: 'PowerOn'
+      description: >
+          The desired power transition to support scheduled power on/off.
+          The default operation supports scheduled power on.
+
+enumerations:
+    - name: Transition
+      description: >
+          The desired power transition.
+      values:
+          - name: 'PowerOn'
+            description: >
+                Support scheduled power on.
+          - name: 'PowerOff'
+            description: >
+                Support scheduled power off.
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
This yaml file is used to generate interfaces for Scheduled Host Transition.

Change-Id: I796d9b981749056cd24f69f83bd3767694f2382f
Signed-off-by: Carol Wang <wangkair@cn.ibm.com>